### PR TITLE
Updates command in the install message

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -9,7 +9,7 @@ Customization
 
 Include this in the user key binding to overwrite default behaviour
 
-    { "keys": ["ctrl+shift+d"], "command": "dev_docs" }
+    { "keys": ["ctrl+shift+d"], "command": "dev_docs_search_selection" }
 
 
 Usage


### PR DESCRIPTION
Current install message still shows `dev_docs` as a command but It's been replaced with `dev_docs_search_selection`.
