### PR TITLE
Send word under cursor to devdocs.io: fix for issue #5

### DIFF
--- a/devdocs.py
+++ b/devdocs.py
@@ -18,7 +18,7 @@ class DevDocsSearchSelectionCommand(sublime_plugin.TextCommand):
         for selection in self.view.sel():
             # if the user didn't select anything, search the currently highlighted word
             if selection.empty():
-                text = self.view.word(selection)
+                selection = self.view.word(selection)
 
             text = self.view.substr(selection)
             SearchFor(text)


### PR DESCRIPTION
This will send the word under the cursor to devdocs.io even if not "selected"

The code did check for an empty selection but the word under the cursor was being assigned to the text variable then overridden.
Fix for #5 
